### PR TITLE
Directory Finding Improved

### DIFF
--- a/clear.py
+++ b/clear.py
@@ -33,8 +33,7 @@ else:
 
 
 # finding current directory
-cwd = os.path.abspath(__file__)
-setup_dir = os.path.dirname(cwd)
+setup_dir = os.getcwd()
 
 #clearing __pycache__
 src_pycache = os.path.join(setup_dir, 'persepolis', '__pycache__')
@@ -56,8 +55,7 @@ if uid != 0:
 
 
 # finding current directory
-cwd = os.path.abspath(__file__)
-setup_dir = os.path.dirname(cwd)
+setup_dir = os.getcwd()
 
 #clearing __pycache__
 src_pycache = os.path.join(setup_dir, 'persepolis', '__pycache__')


### PR DESCRIPTION
I think there is no need to use `os.path.getpath(__file__)`, instead we can simply use `os.getcwd()` method. and by using this, there is no need to `cwd` variable.