### PR TITLE
Directory Finding Improved

### DIFF
--- a/clear.py
+++ b/clear.py
@@ -53,10 +53,6 @@ if uid != 0:
     if you want to clean unwanted files that created by setup tools')
     sys.exit(1)
 
-
-# finding current directory
-setup_dir = os.getcwd()
-
 #clearing __pycache__
 src_pycache = os.path.join(setup_dir, 'persepolis', '__pycache__')
 gui_pycache = os.path.join(setup_dir, 'persepolis', 'gui', '__pycache__')


### PR DESCRIPTION
Instead of using `os.path.abspath(__file__)` and then `os.path.dirname` we can simply use `os.getcwd()`. by using this, there is no need to cwd variable. also there is a redundancy in finding the path in code. I also removed this duplication.